### PR TITLE
add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "toctive",
   "version": "0.0.0",
+  "description": "A monorepo conatins all Toctive private projects",
   "license": "MIT",
   "scripts": {
     "start": "nx serve",


### PR DESCRIPTION
generating a new NX workspace doesn't add a description to `package.json`. So, I added this missing part.